### PR TITLE
Improve keyboard usability

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,11 +28,11 @@
         </div>
 
         <div id="information">
-            <button id="github" title="Github" onclick="window.open('https://github.com/Autophagy/multitimer');">
+            <button id="github" tabindex="-10" title="Github" onclick="window.open('https://github.com/Autophagy/multitimer');">
                 <img src="images/github.png" />
             </button>
 
-            <button id="contact" title="Contact" onclick="window.open('http://www.deadcells.org/about/');">
+            <button tabindex="-20" id="contact" title="Contact" onclick="window.open('http://www.deadcells.org/about/');">
                 <img src="images/mail.png" />
             </button>
         </div>

--- a/js/multitimer.js
+++ b/js/multitimer.js
@@ -50,12 +50,15 @@ var Timer = (function () {
                     <button title="Close the timer" class="close-button" onclick="timers[&quot;' + this.timerID + '&quot;].delete();"><img src="images/close.png" /></button>\
                 </div>\
         </div>');
+
+        $('.timer-title:last input[name=timer-title]').select();
     }
 
     Timer.prototype.delete = function () {
         $(this.selector).remove();
         this.sound.pause();
         delete timers[this.timerID];
+        $('#title-options button:first').focus();
     }
 
     Timer.prototype.togglePlaying = function () {
@@ -77,7 +80,10 @@ var Timer = (function () {
             $(this.selector + ' .timer-time-options input').css("border", "1px solid rgba(0,0,0,0)");
             $(this.selector + ' .timer-time-options input').css("background-color", "rgba(0,0,0,0)");
             $(this.selector+ ' .play-button img').attr("src", "images/pause.png");
+            $('#title-options button:first').focus();
             this.playing = true;
+        } else {
+          $(this.selector + ' .timer-time-options input:first').select();
         }
     }
 
@@ -99,6 +105,7 @@ var Timer = (function () {
         $(this.selector + ' .timer-title input').val('New Timer');
         $(this.selector + ' .timer-type-options select').val('sounds/alarm.mp3');
         $(this.selector + ' .timer-notes textarea').val('');
+        $(this.selector + ' .timer-time-options input:first').select();
     }
 
     Timer.prototype.decrement = function () {


### PR DESCRIPTION
Nice timer!  I actually use it.  Here is a PR that makes it work a little better with a keyboard.
- skip contact buttons with negative tabindex
- focus main add button on start
- select timer name text when creating new timer
- select time control when trying to start a timer with 0 time
- focus back to main add button after start individual timer

Example

![timer](https://cloud.githubusercontent.com/assets/221013/11887917/1b0fce0e-a4fe-11e5-81db-f5da7e0bac41.gif)
